### PR TITLE
Attempt on fixing live-reload over local network

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ module.exports = {
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
 
     if (liveReloadPort && type === 'head') {
-      return '<script src="http://localhost:' + liveReloadPort + '/livereload.js?snipver=1" type="text/javascript"></script>';
+      var src = "' + (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + liveReloadPort + "/livereload.js?snipver=1";
+      return "\n<script type=\"text/javascript\">//<![CDATA[\ndocument.write('<script src=\"" + src + "\" type=\"text/javascript\"><\\/script>')\n//]]></script>\n";
     }
   },
 


### PR DESCRIPTION
This PR is to bring your attention to the issue when live-reload server resides on local network (eg. 192.168.42.1).

Due to the hardcoded `localhost` client attempts to connect to wrong server, which results in the following error:

`GET http://localhost:35729/livereload.js?snipver=1 net::ERR_CONNECTION_REFUSED`

---

NOTE this may not be intended way to fix this since it will require one the following fixes in ember-cli app/addon:
- Updating config for: contentSecurityPolicy to include `'script-src': 'unsafe-eval'`
- or removing dependency of `ember-cli-content-security-policy` (which I did)
