### PR TITLE
Use ember serve host explicitly, instead of inferring

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,13 +12,15 @@ module.exports = {
   },
 
   dynamicScript: function(request) {
+    var liveReloadHost = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_HOST;
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
 
     return "(function() {\n " +
-           "var src = (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + liveReloadPort + "/livereload.js?snipver=1';\n " +
-           "var script    = document.createElement('script');\n " +
-           "script.type   = 'text/javascript';\n " +
-           "script.src    = src;\n " +
+           "var hostAndPort = " + liveReloadHost + ":" + liveReloadPort + ";\n" +
+           "var src         = (location.protocol || 'http:') + '//' + hostAndPort + '/livereload.js?snipver=1';\n " +
+           "var script      = document.createElement('script');\n " +
+           "script.type     = 'text/javascript';\n " +
+           "script.src      = src;\n " +
            "document.getElementsByTagName('head')[0].appendChild(script);\n" +
            "}());";
   },
@@ -30,6 +32,7 @@ module.exports = {
 
     if (options.liveReload !== true) { return; }
 
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_HOST = options.host;
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
 
     app.use('/ember-cli-live-reload.js', function(request, response, next) {


### PR DESCRIPTION
We're using multiple ember-cli apps on the same domain, deployed at different paths. In dev we use nginx to proxy requests to the correct hostname.

Because `window.location.host` is the nginx proxy, and not the ember server, the sweet live-reload breaks.

This proposed change uses the explicit hostname, instead of inferring from window.location, similar to how the `liveReloadPort` value is set explicitly.
