### PR TITLE
Make live reload host configurable

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,15 @@ module.exports = {
 
   dynamicScript: function(request) {
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
+    var liveReloadHostURL = process.env.EMBER_CLI_LIVE_RELOAD_HOSTURL;
+    var host = "' + (location.hostname || 'localhost') + '"; // JS code to figure out correct host
+
+    if (liveReloadHostURL) {
+      host = liveReloadHostURL; // append static string to script if option defined instead
+    }
 
     return "(function() {\n " +
-           "var src = (location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + liveReloadPort + "/livereload.js?snipver=1';\n " +
+           "var src = (location.protocol || 'http:') + '//" + host + ":" + liveReloadPort + "/livereload.js?snipver=1';\n " +
            "var script    = document.createElement('script');\n " +
            "script.type   = 'text/javascript';\n " +
            "script.src    = src;\n " +
@@ -33,6 +39,7 @@ module.exports = {
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.liveReloadBaseUrl || options.baseURL;
+    process.env.EMBER_CLI_LIVE_RELOAD_HOSTURL = options.liveReloadHostUrl;
 
     app.use(options.baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');


### PR DESCRIPTION
Hey, basically in our environment we have vagrant setup. The files generated by Ember CLI - dist - are served by nginx from Vagrant on other domain - say `local.domain`. However we run ember process on Host machine instead of Vagrant (because on Guest environment [Vagrant] it is slow). So when we access `local.domain` it goes through Vagrant and displays our page. The only problem we had was live reload. We fixed 404 of `local.domain/ember-cli-live-reload.js` by specifying:
`"liveReloadBaseUrl": "http://localhost:4200/",`
inside `.ember-cli` file. However after that we had problem because it requested `livereload.js` from `local.domain/livereload.js` instead of `localhost:4200/livereload.js`. It was determined upon `window.location.hostname` which basically resolved to wrong hostname in our environment.

As other values in ember-cli-inject-live-reload project are configurable, we are confused why hostname isn't one of such values.

This commit makes hostname configurable in `.ember-cli` file and solves our issue.

cc @rwjblue 