### PR TITLE
Allow domains in `liveReloadBaseUrl`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,12 +34,12 @@ module.exports = {
     var app = config.app;
     var options = config.options;
     // maintaining `baseURL` for backwards compatibility. See: http://emberjs.com/blog/2016/04/28/baseURL.html
-    var baseURL = options.liveReloadBaseUrl || options.rootURL || options.baseURL;
+    var baseURL = options.rootURL || options.baseURL;
 
     if (options.liveReload !== true) { return; }
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
-    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = baseURL;
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = options.liveReloadBaseUrl || baseURL;
 
     app.use(baseURL + 'ember-cli-live-reload.js', function(request, response, next) {
       response.contentType('text/javascript');


### PR DESCRIPTION
#28 breaks live-reload injection because it does not make the difference between `baseUrl/rootUrl` and `liveReloadBaseUrl`.

It happens in `var baseURL = options.liveReloadBaseUrl || options.rootURL || options.baseURL;`.

Then `app.use(baseURL + 'ember-cli-live-reload.js', ... ` does not work anymore since `app.use` won't accept an url with domain.