### PR TITLE
Update this addon to run before the new serve-file middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "before": "ember-cli:broccoli:watcher"
+    "before": ["serve-files-middleware", "ember-cli:broccoli:watcher"]
   },
   "author": "Robert Jackson",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "ember-addon"
   ],
   "ember-addon": {
-    "before": "serve-files-middleware"
+    "before": "ember-cli:broccoli:watcher"
   },
   "author": "Robert Jackson",
   "license": "MIT",


### PR DESCRIPTION
This PR needs to be merged on top of 1.4.1 since master is currently broken after [ember-cli PR is merged](https://github.com/ember-cli/ember-cli/pull/6633). After this is merged, we will probably need a major version bump (which will be compatible with the ember-cli release that contains this [PR](https://github.com/ember-cli/ember-cli/pull/6633).

cc: @rwjblue 