### PR TITLE
Change the name of middleware to broccoli-watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "ember-addon": {
     "before": [
       "serve-files-middleware",
-      "ember-cli:broccoli:watcher"
+      "broccoli-watcher"
     ]
   },
   "author": "Robert Jackson",


### PR DESCRIPTION
I changed the name to be consistent with the folder name in my ember-cli PR so the name needs to be changed here as well. 

I apologize but we will need another release.

cc: @rwjblue 