### PR TITLE
add cspNonce option to add a nonce attribute to the <script>

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The following options are supported via the `.ember-cli` file:
 |------|-------|
 | `liveReloadJsUrl` | The absolute URL used to load `livereload.js`. If specified, this overrides the `liveReloadPort` option.  |
 | `liveReloadOptions` | JavaScript object for LiveReload options. LiveReload supports a number of [options](https://github.com/livereload/livereload-js#options) for configuring websocket communication, including `https`, `host`, `port`, and others. See advanced example below. |
+| `cspNonce` | optional string to be added as `nonce` attribute in the `ember-cli-live-reload.js`'s script tag, for Content Security Policy purposes. See [ember-cli-content-security-policy](https://github.com/rwjblue/ember-cli-content-security-policy) |
 
 ## Advanced Example Configuration
 
@@ -46,6 +47,8 @@ The following options are supported via the `.ember-cli` file:
     "host": "your-hostname.dev"
   },
 
-  "liveReloadJsUrl": "https://your-hostname.dev/livereload.js"
+  "liveReloadJsUrl": "https://your-hostname.dev/livereload.js",
+
+  "cspNonce": "mydevelnonce"
 }
 ```

--- a/index.js
+++ b/index.js
@@ -6,9 +6,11 @@ module.exports = {
   contentFor: function(type) {
     var liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
     var baseURL = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL;
+    var cspNonce = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_CSP_NONCE;
 
     if (liveReloadPort && type === 'head') {
-      return '<script src="' + baseURL + 'ember-cli-live-reload.js" type="text/javascript"></script>';
+      var nonce = cspNonce ? ('nonce="' + cspNonce + '" ') : '';
+      return '<script ' + nonce + 'src="' + baseURL + 'ember-cli-live-reload.js" type="text/javascript"></script>';
     }
   },
 
@@ -40,6 +42,7 @@ module.exports = {
 
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT = options.liveReloadPort;
     process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL = baseURL;
+    process.env.EMBER_CLI_INJECT_LIVE_RELOAD_CSP_NONCE = options.cspNonce;
 
     var baseURLWithoutHost = baseURL.replace(/^https?:\/\/[^\/]+/, '');
     app.use(baseURLWithoutHost + 'ember-cli-live-reload.js', function(request, response, next) {


### PR DESCRIPTION
for CSP compliance options.

This will allow using strict CSP in development using `script-dynamic` and a nonce.