### PR TITLE
fix undefined error when options.liveReloadPrefix is undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = {
       liveReloadOptions.snipver = 1;
     }
 
-    var liveReloadPath = buildLiveReloadPath(options.liveReloadPrefix);
+    var liveReloadPath = buildLiveReloadPath(options.liveReloadPrefix) || '/';
     return "(function() {\n " +
            (liveReloadOptions ? "window.LiveReloadOptions = " + JSON.stringify(liveReloadOptions) + ";\n " : '') +
            "var srcUrl = " + (options.liveReloadJsUrl ? "'" + options.liveReloadJsUrl + "'" : "null") + ";\n " +


### PR DESCRIPTION
clean-base-url returns undefined if the argument passed is an undefined value. If we receive undefined then replace it with '/'.