### PR TITLE
Passing port and host to livereload.js file as regex fails to parse URL with prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,8 @@ module.exports = {
     return "(function() {\n " +
            (liveReloadOptions ? "window.LiveReloadOptions = " + JSON.stringify(liveReloadOptions) + ";\n " : '') +
            "var srcUrl = " + (options.liveReloadJsUrl ? "'" + options.liveReloadJsUrl + "'" : "null") + ";\n " +
-           "var src = srcUrl || ((location.protocol || 'http:') + '//' + (location.hostname || 'localhost') + ':" + options.liveReloadPort + liveReloadPath +"livereload.js');\n " +
+           "var host= location.hostname || 'localhost';\n " +
+           "var src = srcUrl || ((location.protocol || 'http:') + '//' + host + ':" + options.liveReloadPort + liveReloadPath +"livereload.js?host='+host+'&port='+"+ options.liveReloadPort +");\n " +
            "var script    = document.createElement('script');\n " +
            "script.type   = 'text/javascript';\n " +
            "script.src    = src;\n " +


### PR DESCRIPTION
Livereload.js has a regex to [parse](https://github.com/livereload/livereload-js/blob/master/dist/livereload.js#L529) and get `host` and `port`. If the URL passed is in `localhost:4200/livereloadPrefix/livereload.js` then logic fails to parse it.
I have created a [PR](https://github.com/livereload/livereload-js/pull/78) to fix this issue in livereload.js. But to make it work now we can pass host and port along with URL itself so that we can unblock ourself.