### PR TITLE
Update minimum ember-cli version for scoped path

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
     if (this.parent) {
       let checker = new VersionChecker(this.parent);
       let depedency = checker.for('ember-cli');
-      options.isLatestEmber = depedency.gt('3.5.0-beta.2');
+      options.isLatestEmber = depedency.gt('3.5.0');
     }
     if (options.liveReload !== true) { return; }
 


### PR DESCRIPTION
ember-cli@3.5.0 accidentally shipped without the fix required to support this guard, bumping here to match the patch release.