### PR TITLE
Respect liveReloadPort even if same as ember server port

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,22 +22,18 @@ module.exports = {
     }
 
     let liveReloadPath = buildLiveReloadPath(options.liveReloadPrefix) || '/';
-    let liveReloadPort;
     let path = '';
-    if (options.liveReloadPort !== options.port) {
-      liveReloadPort = options.liveReloadPort
-    }
     if (options.isLatestEmber && options.liveReloadPrefix) {
       path = `&path=${options.liveReloadPrefix}/livereload`;
     }
     return `(function() {${liveReloadOptions ? "\n  window.LiveReloadOptions = " + JSON.stringify(liveReloadOptions) + ";" : ''}
   var srcUrl = ${options.liveReloadJsUrl ? "'" + options.liveReloadJsUrl + "'" : null};
-  var host= location.hostname || 'localhost';
-  var liveReloadPort = ${liveReloadPort};
-  var defaultPort = location.protocol === 'https:' ? 443 : 80;
-  var port = liveReloadPort || location.port || defaultPort;
+  var host = location.hostname || 'localhost';
+  var useCustomPort = ${options.liveReloadPort !== options.port} || location.port !== ${options.liveReloadPort};
+  var defaultPort = location.port || (location.protocol === 'https:' ? 443 : 80);
+  var port = useCustomPort ? ${options.liveReloadPort} : defaultPort;
   var path = '${path}';
-  var prefixURL = ${liveReloadPort ? "(location.protocol || 'http:') + '//' + host + ':' + " + liveReloadPort : "''"};
+  var prefixURL = useCustomPort ? (location.protocol || 'http:') + '//' + host + ':' + ${options.liveReloadPort} : '';
   var src = srcUrl || prefixURL + '${liveReloadPath + 'livereload.js?port='}' + port + '&host=' + host + path;
   var script    = document.createElement('script');
   script.type   = 'text/javascript';

--- a/tests/inject-live-reload-test.js
+++ b/tests/inject-live-reload-test.js
@@ -95,6 +95,15 @@ describe('dynamicScript returns right script when', hooks => {
     assert.strictEqual(actual, 'http://localhost:35729/_lr/livereload.js?port=35729&host=localhost&path=_lr/livereload');
   });
 
+  it('liveReloadPort and port are same, but both are different from location.port', assert => {
+    options.liveReloadPort = '9999';
+    options.port = '9999';
+    let script = InjectLiveReload.dynamicScript(options);
+    let actual = getScriptSrc(script);
+
+    assert.strictEqual(actual, 'http://localhost:9999/_lr/livereload.js?port=9999&host=localhost&path=_lr/livereload');
+  });
+
   it('liveReloadPrefix is provided', assert => {
     options.liveReloadPrefix = 'other-lr-path';
     let script = InjectLiveReload.dynamicScript(options);
@@ -161,12 +170,12 @@ describe('serverMiddleware', hooks => {
       response.on('end', () => {
       assert.equal(buf, `(function() {
   var srcUrl = null;
-  var host= location.hostname || 'localhost';
-  var liveReloadPort = undefined;
-  var defaultPort = location.protocol === 'https:' ? 443 : 80;
-  var port = liveReloadPort || location.port || defaultPort;
+  var host = location.hostname || 'localhost';
+  var useCustomPort = false || location.port !== 4200;
+  var defaultPort = location.port || (location.protocol === 'https:' ? 443 : 80);
+  var port = useCustomPort ? 4200 : defaultPort;
   var path = '';
-  var prefixURL = '';
+  var prefixURL = useCustomPort ? (location.protocol || 'http:') + '//' + host + ':' + 4200 : '';
   var src = srcUrl || prefixURL + '/livereload.js?port=' + port + '&host=' + host + path;
   var script    = document.createElement('script');
   script.type   = 'text/javascript';


### PR DESCRIPTION
Previously, we could serve Ember at `:4200` and load the app via another port (`:3000`) if we specified:
```
  "liveReloadBaseUrl": "http://localhost:4200/",
  "liveReloadPort": 4200
```

One use case is the ember-cli-deploy lightning strategy development workflow:
- `ember serve -p 4200`
- Rails app at `:3000` that reads index.html from redis
- Currently, when accessing the app at `:3000`:
  - http://localhost:4200/ember-cli-live-reload.js is loaded thanks to `liveReloadBaseUrl`
  - http://localhost:3000/_lr/livereload.js?port=3000&host=localhost&path=_lr/livereload is loaded when we actually want 4200

---

This regression was introduced in https://github.com/ember-cli/ember-cli-inject-live-reload/pull/54:
> construct URL only if live-reload-port is not same ember serve port.

This should be: "construct URL if live-reload-port is different from ember server port, or different from location.port"

---

This PR might also solve https://github.com/ember-cli/ember-cli-inject-live-reload/issues/68 and https://github.com/ember-cli/ember-cli-inject-live-reload/issues/46 (though it's difficult to tell based on issue description alone)