### PR TITLE
Add `data-embroider-ignore` attribute if embroider is present

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,12 +6,25 @@ const VersionChecker = require('ember-cli-version-checker');
 module.exports = {
   name: 'live-reload-middleware',
 
+  included: function() {
+    this._super.included.apply(this, arguments);
+
+    if (this.parent) {
+      let checker = new VersionChecker(this.parent);
+      let depedency = checker.for('@embroider/compat');
+      this.hasEmbroider = depedency.gt('0.1.0');
+    }
+  },
+
   contentFor: function(type) {
     let liveReloadPort = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_PORT;
     let baseURL = process.env.EMBER_CLI_INJECT_LIVE_RELOAD_BASEURL;
 
     if (liveReloadPort && type === 'head') {
-      return '<script src="' + baseURL + 'ember-cli-live-reload.js" type="text/javascript"></script>';
+      let hasEmbroider = this.hasEmbroider;
+      return `<script src="${baseURL}ember-cli-live-reload.js" type="text/javascript"${
+        hasEmbroider ? ' data-embroider-ignore="true"' : ''
+      }></script>`;
     }
   },
 

--- a/tests/inject-live-reload-test.js
+++ b/tests/inject-live-reload-test.js
@@ -19,7 +19,13 @@ describe('contenFor returns', () => {
   it('nothing if type is not head', assert => {
     let scriptTag = InjectLiveReload.contentFor('body');
     assert.equal(scriptTag, undefined);
-  })
+  });
+  it('add attribute if @embroider/compat is present', assert => {
+    InjectLiveReload.hasEmbroider = true;
+    let scriptTag = InjectLiveReload.contentFor('head');
+    assert.equal(scriptTag, '<script src="test/ember-cli-live-reload.js" type="text/javascript" data-embroider-ignore="true"></script>');
+    InjectLiveReload.hasEmbroider = false;
+  });
 });
 
 describe('dynamicScript returns right script when', hooks => {


### PR DESCRIPTION
To avoid the warning output by embroider:

```
warning: in index.html <script src="ember-cli-live-reload.js"> does not exist on disk. If this is intentional, use a data-embroider-ignore attribute.
```