### PR TITLE
Fix Raw Domain Ports

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,7 +29,7 @@ module.exports = {
     return `(function() {${liveReloadOptions ? "\n  window.LiveReloadOptions = " + JSON.stringify(liveReloadOptions) + ";" : ''}
   var srcUrl = ${options.liveReloadJsUrl ? "'" + options.liveReloadJsUrl + "'" : null};
   var host = location.hostname || 'localhost';
-  var useCustomPort = ${options.liveReloadPort !== options.port} || location.port !== ${options.liveReloadPort};
+  var useCustomPort = ${options.liveReloadPort !== options.port} || (location.port !== '' && location.port !== ${options.liveReloadPort});
   var defaultPort = location.port || (location.protocol === 'https:' ? 443 : 80);
   var port = useCustomPort ? ${options.liveReloadPort} : defaultPort;
   var path = '${path}';

--- a/tests/inject-live-reload-test.js
+++ b/tests/inject-live-reload-test.js
@@ -135,6 +135,25 @@ describe('dynamicScript returns right script when', hooks => {
 
     assert.strictEqual(actual, '/_lr/livereload.js?port=4200&host=localhost');
   });
+
+  it('sets the proper port for http when served via domain', assert => {
+    location.port = '';
+
+    let script = InjectLiveReload.dynamicScript(options);
+    let actual = getScriptSrc(script);
+
+    assert.strictEqual(actual, '/_lr/livereload.js?port=80&host=localhost&path=_lr/livereload');
+  });
+
+  it('sets the proper port for http when served via domain', assert => {
+    location.port = '';
+    location.protocol = 'https:'
+
+    let script = InjectLiveReload.dynamicScript(options);
+    let actual = getScriptSrc(script);
+
+    assert.strictEqual(actual, '/_lr/livereload.js?port=443&host=localhost&path=_lr/livereload');
+  });
 });
 
 describe('serverMiddleware', hooks => {
@@ -171,7 +190,7 @@ describe('serverMiddleware', hooks => {
       assert.equal(buf, `(function() {
   var srcUrl = null;
   var host = location.hostname || 'localhost';
-  var useCustomPort = false || location.port !== 4200;
+  var useCustomPort = false || (location.port !== '' && location.port !== 4200);
   var defaultPort = location.port || (location.protocol === 'https:' ? 443 : 80);
   var port = useCustomPort ? 4200 : defaultPort;
   var path = '';


### PR DESCRIPTION
When serving via a proxy like nginx (and without a port), location.port is an empty string. This means useCustomPort is currently set to true unintentionally. By checking that port is not an empty string this means that the proper 80/443 port is set on portless proxied requests