### PR TITLE
support empty rootURL with Ember CLI >= 5.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,6 +49,12 @@ module.exports = {
     let self = this;
     // maintaining `baseURL` for backwards compatibility. See: http://emberjs.com/blog/2016/04/28/baseURL.html
     let baseURL = options.liveReloadBaseUrl ?? options.rootURL ?? options.baseURL;
+
+    // express requires absolute paths
+    if (baseURL === '') {
+      baseURL = '/';
+    }
+
     if (this.parent) {
       let checker = new VersionChecker(this.parent);
       let depedency = checker.for('ember-cli');

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ module.exports = {
 
     let self = this;
     // maintaining `baseURL` for backwards compatibility. See: http://emberjs.com/blog/2016/04/28/baseURL.html
-    let baseURL = options.liveReloadBaseUrl || options.rootURL || options.baseURL;
+    let baseURL = options.liveReloadBaseUrl ?? options.rootURL ?? options.baseURL;
     if (this.parent) {
       let checker = new VersionChecker(this.parent);
       let depedency = checker.for('ember-cli');


### PR DESCRIPTION
Until Ember CLI v5 the `baseURL` was set to `'/'` if `rootURL` was an empty string. Since Ember CLI v5 the `baseURL` is not set anymore on the `config.options` object at all. This change causes ember-cli-live-reload to break if applications set `baseURL = ''` in the `config/environment.js`.

```
TypeError: Cannot read properties of undefined (reading 'replace')
    at Class.serverMiddleware (/path/to/code/node_modules/ember-cli-inject-live-reload/lib/index.js:62:38)
    at ExpressServerTask.<anonymous> (/path/to/code/node_modules/ember-cli/lib/tasks/server/express-server.js:107:24)
    at promiseMapSeries (/path/to/code/node_modules/ember-cli/node_modules/promise-map-series/index.js:7:24)
    at async ExpressServerTask.startHttpServer (/path/to/code/node_modules/ember-cli/lib/tasks/server/express-server.js:258:5)
    at async ServeTask.run (/path/to/code/node_modules/ember-cli/lib/tasks/serve.js:96:5)
    at async Class.run (/path/to/code/node_modules/ember-cli/lib/commands/serve.js:106:5)
    at async /path/to/code/node_modules/ember-cli/lib/cli/cli.js:173:32
```

Nullish coalescing operator should solve the issue as it does not fall back to `baseURL` if `rootURL` is an empty string.

Please find a simple reproduction here: https://github.com/jelhan/ember-app-with-relative-root-url `ember serve` is working fine for the last commit using Ember CLI v4.12. If you go back one commit, which uses Ember CLI v5.0 it breaks with the error mentioned above.